### PR TITLE
Add TWZRD Agent Intel for on-chain agent trust scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ There is some specific keywords that trigger some actions from GPTS; here are so
 * [FridaGPT](https://chat.openai.com/g/g-KwZVA8dTp-fridagpt): A Frida focussed GPT to help reverse engineers in writing Frida scripts.
 * [RedTeamGPT](https://chat.openai.com/g/g-j8ldT0QAO-redteamgpt): Advanced guide in red teaming, pentest, attack and cybersecurity.
 * [DFIR-GPT](https://chat.openai.com/g/g-11Pfha6Uq-dfir-gpt): A GPT Agent that tries to provide Digital Forensics and Incident Response (DFIR) technical advice and guidance. 
+* [TWZRD Agent Intel](https://intel.twzrd.xyz): On-chain agent trust scoring for Solana agents. Provides reputation scores and preflight checks for AI agents using HTTP 402 micro-payments — useful for verifying agent identity before granting permissions in multi-agent security pipelines.
 
 ## Contributing <a href="https://github.com/fr0gger/Awesome-GPT-Agents/graphs/contributors"> ![GitHub](https://img.shields.io/github/contributors/fr0gger/Awesome-GPT-Agents) </a>
 


### PR DESCRIPTION
## What this adds

[TWZRD Agent Intel](https://intel.twzrd.xyz) — on-chain agent trust scoring for Solana-based AI agents.

**Why it belongs here:** As autonomous AI agents operate in Web3 environments, verifying agent identity becomes a security concern. TWZRD Agent Intel provides reputation scoring and preflight checks for Solana wallets, allowing multi-agent security pipelines to verify an agent's on-chain history before granting permissions or executing high-value operations.

Tools exposed via MCP:
- `score_agent(wallet)` — free reputation score
- `preflight_check(wallet)` — free deployment safety check  
- `get_trust_receipt(wallet)` — HTTP 402 paid cryptographic trust receipt

**MCP config:**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```